### PR TITLE
Make Exception Catchable

### DIFF
--- a/Sound/File/Sndfile/Exception.hs
+++ b/Sound/File/Sndfile/Exception.hs
@@ -20,9 +20,7 @@ data Exception =
   | UnsupportedEncoding { errorString :: String }
   deriving (Typeable, Show)
 
-instance E.Exception (Exception) where
-    toException   = SomeException
-    fromException = const Nothing
+instance E.Exception (Exception)
 
 -- | Construct 'Exception' from error code and string.
 fromErrorCode :: Int -> String -> Exception


### PR DESCRIPTION
This commit makes it possible to catch exceptions raised from Sndfile, for example:

import qualified Sound.File.Sndfile as SF
import qualified Sound.File.Sndfile.Buffer.Vector as BV

test = (SF.readFile "non-existent-file" :: IO (SF.Info, Maybe (BV.Buffer Double)))
       `SF.catch` (\e -> error $ "Caught exception "
                         ++ SF.errorString (e :: SF.Exception))

will now print "Caught exception System error : No such file or directory."
