### PR TITLE
Export access to C SNDFILE*

### DIFF
--- a/Sound/File/Sndfile.hs
+++ b/Sound/File/Sndfile.hs
@@ -16,7 +16,7 @@ module Sound.File.Sndfile
     -- *Stream info
     Info(..), duration, defaultInfo, checkFormat,
     -- *Stream handle operations
-    Handle, hInfo, hIsSeekable,
+    Handle, hInfo, hPtr, HandlePtr, hIsSeekable,
     IOMode(..), openFile, getFileInfo, hFlush, hClose,
     SeekMode(..), hSeek, hSeekRead, hSeekWrite
     -- *I\/O functions

--- a/Sound/File/Sndfile/Interface.chs
+++ b/Sound/File/Sndfile/Interface.chs
@@ -244,8 +244,9 @@ checkHandle handle = do
 -- | Abstract file handle.
 data Handle = Handle {
     hInfo :: Info,      -- ^Return the stream 'Info' associated with the 'Handle'.
-    hPtr :: HandlePtr
+    hPtr :: HandlePtr   -- ^Return the bare C pointer for the 'Handle'.
 }
+-- | Corresponds to a @SNDFILE*@ in C.
 type HandlePtr = Ptr ()
 
 -- | I\/O mode.


### PR DESCRIPTION
I'd like to tweak some of the `libsndfile` settings listed [here](http://www.mega-nerd.com/libsndfile/command.html), but also use the nice interface of `hsndfile`. Rather than include a whole set of Haskell bindings for the commands, I think it'd make sense to just export access to the C `SNDFILE*` pointer, so that anyone who needs functions without bindings can just write individual bindings themselves.
