### PR TITLE
Fixes building on macos

### DIFF
--- a/hsndfile.cabal
+++ b/hsndfile.cabal
@@ -32,6 +32,8 @@ Library
                         Sound.File.Sndfile.Interface
   Ghc-Options:          -Wall -fno-warn-name-shadowing
   Pkgconfig-Depends:	sndfile >= 1.0.25
+  if os(darwin)
+    cpp-options: -D_Nullable= -D_Nonnull=
 
 Source-Repository head
   Type:                 git


### PR DESCRIPTION
I get the following build error when building on macos:

```
    Preprocessing library hsndfile-0.8.0...
    c2hs: C header contains errors:

    /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk/usr/include/stdio.h:133: (column 19) [ERROR]  >>> Syntax error !
      The symbol `_close' does not fit here.
```

I found this commit (https://github.com/gtk2hs/gtk2hs/commit/3cfd8026be12c6c137c555892139ef6f2150dd48) solving the same issue on gtk2th (https://github.com/gtk2hs/gtk2hs/issues/183). Works here as well.
