### PR TITLE
added lib dirs for Ubuntu installation

### DIFF
--- a/hsndfile.cabal
+++ b/hsndfile.cabal
@@ -34,6 +34,7 @@ Library
   Pkgconfig-Depends:	sndfile >= 1.0.25
   if os(darwin)
     cpp-options: -D_Nullable= -D_Nonnull=
+  extra-lib-dirs:       /usr/local/lib
 
 Source-Repository head
   Type:                 git


### PR DESCRIPTION
When I installed libsndfile on Ubuntu, it automatically installed to /usr/local/lib, and I needed to specify where that was in order for cabal to install hsndfile.  This adds /usr/local/lib to the cabal file so that cabal can find it without extra specification.